### PR TITLE
[feat] Add centralized icon import library

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,16 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { fab } from '@fortawesome/free-brands-svg-icons'
+import {
+  faBell,
+  faComment,
+  faUserShield,
+  faCalendar,
+  faClock,
+  faMapMarkerAlt,
+  faUser
+} from '@fortawesome/free-solid-svg-icons'
 
 import Routes from './Routes'
 import Navbar from './components/Navbar'
@@ -8,8 +19,18 @@ import GoogleUserLogin from './components/GoogleUserLogin'
 // import EventForm from './components/EventForm'
 import LandingPage from './pages/LandingPage'
 import Footer from './components/Footer'
-
 import './App.scss'
+
+library.add(
+  fab,
+  faBell,
+  faComment,
+  faUserShield,
+  faCalendar,
+  faClock,
+  faMapMarkerAlt,
+  faUser
+)
 
 const App = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)

--- a/client/src/components/Event/index.tsx
+++ b/client/src/components/Event/index.tsx
@@ -3,13 +3,6 @@ import { Link } from 'react-router-dom'
 import { useCookies } from 'react-cookie'
 import jwt from 'jsonwebtoken'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faUserShield,
-  faCalendar,
-  faClock,
-  faMapMarkerAlt,
-  faUser
-} from '@fortawesome/free-solid-svg-icons'
 
 import Button from '../Button'
 import FormInputFiled from '../FormInputField'
@@ -57,7 +50,7 @@ const Event = ({
             <div className='event__icon-wrapper'>
               <FontAwesomeIcon
                 className='event__info-text event__info-text--icon'
-                icon={faUserShield}
+                icon='user-shield'
               />
             </div>
             <Link className='event__link' to={`/${userId}`}>
@@ -70,7 +63,7 @@ const Event = ({
             <div className='event__icon-wrapper'>
               <FontAwesomeIcon
                 className='event__info-text event__info-text--icon'
-                icon={faCalendar}
+                icon='calendar'
               />
             </div>
             <p className='event__info-text'>{formattedDate}</p>
@@ -79,7 +72,7 @@ const Event = ({
             <div className='event__icon-wrapper'>
               <FontAwesomeIcon
                 className='event__info-text event__info-text--icon'
-                icon={faClock}
+                icon='clock'
               />
             </div>
             <p className='event__info-text'>{formattedTime}</p>
@@ -88,7 +81,7 @@ const Event = ({
             <div className='event__icon-wrapper'>
               <FontAwesomeIcon
                 className='event__info-text event__info-text--icon'
-                icon={faMapMarkerAlt}
+                icon='map-marker-alt'
               />
             </div>
             <p className='event__info-text'>{address}</p>
@@ -97,7 +90,7 @@ const Event = ({
             <div className='event__icon-wrapper'>
               <FontAwesomeIcon
                 className='event__info-text event__info-text--icon'
-                icon={faUser}
+                icon='user'
               />
             </div>
             <span className='event__info-text'>{`${participants}/`}</span>

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faGithub } from '@fortawesome/free-brands-svg-icons'
 
 import logo from '../../Assets/logoDark.svg'
 import './Footer.scss'
@@ -33,7 +32,7 @@ const Footer = () => {
           href='https://github.com/MikeVedsted/JoinMe'
           target='a_blank'
         >
-          <FontAwesomeIcon className='footer__icon' icon={faGithub} />
+          <FontAwesomeIcon className='footer__icon' icon={['fab', 'github']} />
         </a>
       </div>
     </div>

--- a/client/src/components/FormDropdownField/DropdownField.scss
+++ b/client/src/components/FormDropdownField/DropdownField.scss
@@ -1,16 +1,14 @@
 @import '../../SCSS/config';
 
 .form {
-  
   &__label {
     font-family: $montserrat;
     color: $textDark;
     font-weight: 600;
-  
+
     &--required {
       color: $primary;
     }
-    
   }
 
   &__field {
@@ -24,7 +22,5 @@
     &--option {
       padding: 0;
     }
-
   }
-
 }

--- a/client/src/components/FormInputField/InputField.scss
+++ b/client/src/components/FormInputField/InputField.scss
@@ -5,11 +5,10 @@
     font-family: $montserrat;
     color: $textDark;
     font-weight: 600;
-   
+
     &--required {
       color: $primary;
     }
-    
   }
 
   &__field {
@@ -20,5 +19,4 @@
     margin: 0 0 20px 0;
     padding: 5px 0;
   }
-
 }

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTimes } from '@fortawesome/free-solid-svg-icons'
 
 import { ModalProps } from '../../types'
 import './Modal.scss'
@@ -10,7 +9,7 @@ const Modal = ({ closeModal, content: Content }: ModalProps) => {
     <div className='modal'>
       <div className='modal__window'>
         <button className='modal__close-button' onClick={closeModal}>
-          <FontAwesomeIcon icon={faTimes} />
+          <FontAwesomeIcon icon='times' />
         </button>
         {Content}
       </div>

--- a/client/src/components/Navbar/index.tsx
+++ b/client/src/components/Navbar/index.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useCookies } from 'react-cookie'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBell, faComment } from '@fortawesome/free-solid-svg-icons'
 
 import GoogleLogin from '../GoogleUserLogin'
 import logoDark from '../../Assets/logoDark.svg'
@@ -29,8 +28,8 @@ const Navbar = () => {
       />
       {user_id ? (
         <div className='nav__icons'>
-          <FontAwesomeIcon className='nav__icon' icon={faBell} />
-          <FontAwesomeIcon className='nav__icon' icon={faComment} />
+          <FontAwesomeIcon className='nav__icon' icon='bell' />
+          <FontAwesomeIcon className='nav__icon' icon='comment' />
           <Link to={`/${user_id}`}>
             <img
               className='nav__image nav__image--profile'


### PR DESCRIPTION
Issue [#106](https://github.com/MikeVedsted/JoinMe/issues/106) 

Centralized icons. Plus refactor some files where icons are used.

Feel free to suggest changes.

New way to use icons:
- import icon in app.tsx if it is not imported
- use that icon name in ur component. For ex:
```
<FontAwesomeIcon className='nav__icon' icon='bell' />
<FontAwesomeIcon className='nav__icon' icon='comment' />
```
Where `bell` and `comment` are faBell and faComment.  `faMapMarkerAlt` -> `map-market-alt`

If it is a brand then `icon={['fab', 'github']} `. With brand It is NOT needed to import every brand icon. Imported `fab` has all brands.

More details: [https://fontawesome.com/how-to-use/on-the-web/using-with/react](https://fontawesome.com/how-to-use/on-the-web/using-with/react)