### PR TITLE
[feat] Add slider to EventSearch component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,16 +12,14 @@ import {
   faUser
 } from '@fortawesome/free-solid-svg-icons'
 
-// import Routes from './Routes'
-// import Navbar from './components/Navbar'
+import Routes from './Routes'
+import Navbar from './components/Navbar'
 // import Modal from './components/Modal'
 // import GoogleUserLogin from './components/GoogleUserLogin'
 // import EventForm from './components/EventForm'
-// import LandingPage from './pages/LandingPage'
-// import Footer from './components/Footer'
-// import MyEventsSidebar from './components/MyEventsSidebar'
-import { useFormFields } from './hooks/useFormFields'
-import EventSearch from './components/EventSearch'
+import LandingPage from './pages/LandingPage'
+import Footer from './components/Footer'
+import MyEventsSidebar from './components/MyEventsSidebar'
 import './App.scss'
 
 library.add(
@@ -36,20 +34,9 @@ library.add(
 )
 
 const App = () => {
-  const [address, setAddress] = useState({})
-  const [fields, handleFields] = useFormFields({
-    category: '',
-    distance: '20'
-  })
-
-  const handleSubmit = () => {
-    console.log(fields)
-    console.log(address)
-  }
-
   return (
     <>
-      {/* <Navbar /> */}
+      <Navbar />
       {/* <LandingPage /> */}
       {/* <div style={{ padding: '40px' }}>
         <MyEventsSidebar />
@@ -77,15 +64,8 @@ const App = () => {
       <Link to={'/test-protected'}>Auth protected route</Link> */}
       {/* <h3>Create event form</h3>
       <EventForm />*/}
-      {/* <Routes />
-      <Footer /> */}
-      <EventSearch
-        distance={fields.distance}
-        fields={fields}
-        handleFields={handleFields}
-        handleSubmit={handleSubmit}
-        setAddress={setAddress}
-      />
+      <Routes />
+      <Footer />
     </>
   )
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,14 +12,16 @@ import {
   faUser
 } from '@fortawesome/free-solid-svg-icons'
 
-import Routes from './Routes'
-import Navbar from './components/Navbar'
+// import Routes from './Routes'
+// import Navbar from './components/Navbar'
 // import Modal from './components/Modal'
 // import GoogleUserLogin from './components/GoogleUserLogin'
 // import EventForm from './components/EventForm'
-import LandingPage from './pages/LandingPage'
-import Footer from './components/Footer'
-import MyEventsSidebar from './components/MyEventsSidebar'
+// import LandingPage from './pages/LandingPage'
+// import Footer from './components/Footer'
+// import MyEventsSidebar from './components/MyEventsSidebar'
+import { useFormFields } from './hooks/useFormFields'
+import EventSearch from './components/EventSearch'
 import './App.scss'
 
 library.add(
@@ -34,9 +36,20 @@ library.add(
 )
 
 const App = () => {
+  const [address, setAddress] = useState({})
+  const [fields, handleFields] = useFormFields({
+    category: '',
+    distance: '20'
+  })
+
+  const handleSubmit = () => {
+    console.log(fields)
+    console.log(address)
+  }
+
   return (
     <>
-      <Navbar />
+      {/* <Navbar /> */}
       {/* <LandingPage /> */}
       {/* <div style={{ padding: '40px' }}>
         <MyEventsSidebar />
@@ -64,8 +77,15 @@ const App = () => {
       <Link to={'/test-protected'}>Auth protected route</Link> */}
       {/* <h3>Create event form</h3>
       <EventForm />*/}
-      <Routes />
-      <Footer />
+      {/* <Routes />
+      <Footer /> */}
+      <EventSearch
+        distance={fields.distance}
+        fields={fields}
+        handleFields={handleFields}
+        handleSubmit={handleSubmit}
+        setAddress={setAddress}
+      />
     </>
   )
 }

--- a/client/src/components/EventSearch/EventSearch.scss
+++ b/client/src/components/EventSearch/EventSearch.scss
@@ -1,7 +1,19 @@
 @import '../../SCSS/config';
 
 .search-box {
+  background-color: #f0f0f0;
+  border-radius: 10px;
+  padding: 20px;
+  width: 400px;
+  margin: 20px;
+
   &__button {
     @include flexCenter;
+  }
+
+  &__title {
+    font-size: $sub-head;
+    text-align: center;
+    margin-top: 0;
   }
 }

--- a/client/src/components/EventSearch/index.tsx
+++ b/client/src/components/EventSearch/index.tsx
@@ -9,8 +9,8 @@ import Button from '../Button'
 import './EventSearch.scss'
 
 const EventSearch = ({
-  fields,
-  handleFields,
+  distance,
+  handleFieldChange,
   handleSubmit,
   setAddress
 }: EventSearchProps) => {
@@ -21,7 +21,7 @@ const EventSearch = ({
         label='Category'
         id='category'
         options={eventCategories}
-        onBlur={handleFields}
+        onBlur={handleFieldChange}
       />
       <label className='form__label'>
         Location
@@ -31,8 +31,8 @@ const EventSearch = ({
         Distance from location
         <FormSlider
           id='distance'
-          value={fields.distance}
-          onChange={handleFields}
+          value={distance}
+          onChange={handleFieldChange}
         />
       </label>
       <div className='search-box__button'>

--- a/client/src/components/EventSearch/index.tsx
+++ b/client/src/components/EventSearch/index.tsx
@@ -2,26 +2,45 @@ import React from 'react'
 
 import FormDropdownField from '../FormDropdownField'
 import GoogleAutoComplete from '../GoogleAutoComplete'
+import FormSlider from '../FormSlider'
 import { eventCategories } from '../../util/constants/eventCategories'
+import { EventSearchProps } from '../../types'
 import Button from '../Button'
 import './EventSearch.scss'
 
-const EventSearch = () => {
+const EventSearch = ({
+  fields,
+  handleFields,
+  handleSubmit,
+  setAddress
+}: EventSearchProps) => {
   return (
     <div className='search-box'>
+      <h2 className='search-box__title'>Search events</h2>
       <FormDropdownField
         label='Category'
         id='category'
         options={eventCategories}
-        onBlur={() => console.log('blurred!!')}
+        onBlur={handleFields}
       />
-      <GoogleAutoComplete handleAddress={() => console.log('handled!!')} />
+      <label className='form__label'>
+        Location
+        <GoogleAutoComplete handleAddress={setAddress} />
+      </label>
+      <label className='form__label'>
+        Distance from location
+        <FormSlider
+          id='distance'
+          value={fields.distance}
+          onChange={handleFields}
+        />
+      </label>
       <div className='search-box__button'>
         <Button
-          type='button'
+          type='submit'
           text='Search'
           modifier='primary'
-          onClick={() => console.log('clicked')}
+          onClick={handleSubmit}
         />
       </div>
     </div>

--- a/client/src/components/FormSlider/index.tsx
+++ b/client/src/components/FormSlider/index.tsx
@@ -7,14 +7,16 @@ const FormSlider = ({
   minRange = 0,
   maxRange = 100,
   steps = 5,
-  initialValue = 20
+  initialValue = 20,
+  id,
+  value,
+  onChange
 }: FormSliderProps) => {
-  const [value, setValue] = useState(initialValue)
   const [relativeValue, setRelativeValue] = useState(initialValue)
   const [thumbPosition, setThumbPosition] = useState('')
 
   useEffect(() => {
-    setRelativeValue(((value - minRange) * 100) / (maxRange - minRange))
+    setRelativeValue(((Number(value) - minRange) * 100) / (maxRange - minRange))
     const newPosition = `calc(${relativeValue}% + (${
       8 - relativeValue * 0.15
     }px))`
@@ -30,6 +32,7 @@ const FormSlider = ({
         type='range'
         min={minRange}
         max={maxRange}
+        id={id}
         step={steps}
         style={{
           backgroundImage: `linear-gradient(
@@ -42,9 +45,7 @@ const FormSlider = ({
         }}
         value={value}
         className='slider__range'
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          setValue(e.target.valueAsNumber)
-        }
+        onChange={onChange}
       />
       <div className='slider__subset-labels'>
         <p className='slider__subset-labels--text'>{minRange} km</p>

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -126,8 +126,7 @@ export type NavDropdownProps = {
 
 export type EventSearchProps = {
   handleSubmit: () => void
-  handleFields: () => void
+  handleFieldChange: () => void
   distance: string
-  fields: { [key: string]: any }
   setAddress: Dispatch<SetStateAction<{}>>
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,5 @@
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
+import { Dispatch, SetStateAction } from 'react'
 
 export const FETCH_ALL_EVENTS = 'FETCH_ALL_EVENTS'
 export const GET_ERRORS = 'GET_ERRORS'
@@ -66,6 +67,7 @@ export type InputFieldProps = {
   modifier?: string
   required?: boolean
 }
+
 export type DropdownProps = {
   label: string
   id: string
@@ -95,10 +97,13 @@ export type ModalProps = {
 }
 
 export type FormSliderProps = {
+  id: string
+  value: string
   minRange?: number
   maxRange?: number
   steps?: number
   initialValue?: number
+  onChange: () => void
 }
 
 export type NavDropdownLinkProps = {
@@ -117,4 +122,12 @@ export type NavDropdownProps = {
   display: boolean
   setDropdownHidden: (option: boolean) => void
   userId: string
+}
+
+export type EventSearchProps = {
+  handleSubmit: () => void
+  handleFields: () => void
+  distance: string
+  fields: { [key: string]: any }
+  setAddress: Dispatch<SetStateAction<{}>>
 }


### PR DESCRIPTION
Fixes #123 

Guys, I added the slider component to the `EventSearch` and in the `App.tsx` (_working example, but it will be removed before merging_) I can get the data from the `category`, `address` and `distance`, but I'm not sure this is the best solution. Could you please check this and let me know if I need to fix something?
@Chiranjibichapagain  is working on the `HomePage` so he would import the `EventSearch` there, filter the events based on the data that he'll get and then return the filtered events.

It looks like this right now, but we can adjust it later, the most important is to check if the logic is correct.
![Screenshot 2020-12-21 at 14 46 56](https://user-images.githubusercontent.com/45233290/102784103-2fbff300-439c-11eb-9182-e787141f0477.png)
