### PR TITLE
[style] Refactor button styling

### DIFF
--- a/client/src/components/Button/Button.scss
+++ b/client/src/components/Button/Button.scss
@@ -4,7 +4,7 @@
   font-family: $roboto;
   font-size: $text;
   color: $textLight;
-  background-color: $default;  
+  background-color: $default;
   border: 1px solid $default;
   border-radius: 4px;
   flex-grow: 1;
@@ -12,7 +12,7 @@
   margin: 5px 0;
   cursor: pointer;
   transition: 0.3s ease-in-out;
- 
+
   &--disabled {
     opacity: 0.7;
   }
@@ -68,7 +68,7 @@
 @media only screen and (max-width: 1024px) {
   .button {
     height: 45px;
-    
+
     &--inline {
       height: auto;
     }

--- a/client/src/components/Button/Button.scss
+++ b/client/src/components/Button/Button.scss
@@ -1,49 +1,47 @@
 @import '../../SCSS/config';
 
 .button {
-  width: 100%;
   font-family: $roboto;
-  border-style: none;
-  border-radius: 4px;
-  background-color: $default;
-  padding: 5px 10px;
-  // margin: 10px 10px;
   font-size: $text;
   color: $textLight;
+  background-color: $default;  
+  border: 1px solid $default;
+  border-radius: 4px;
+  flex-grow: 1;
+  padding: 5px 10px;
+  margin: 5px 0;
   cursor: pointer;
   transition: 0.3s ease-in-out;
-
+ 
   &--disabled {
     opacity: 0.7;
-    color: rgb(82, 82, 82);
   }
 
   &--primary {
     background-color: $primary;
-    font-size: $text;
-    color: $textLight;
+    border-color: $primary;
   }
 
   &--primary:hover {
     background-color: white;
-    border: 1px solid $primary;
+    border-color: $primary;
     color: $primary;
   }
 
   &--secondary {
     background-color: $secondary;
-    font-size: $text;
+    border-color: $secondary;
     color: $textDark;
   }
 
   &--secondary:hover {
     background-color: white;
-    border: 1px solid $secondary;
-    color: $textDark;
+    border-color: $secondary;
   }
 
   &--large-active {
     background-color: $primary;
+    border-color: $primary;
     font-size: $sub-head;
     color: $textLight;
     text-align: left;
@@ -51,6 +49,7 @@
 
   &--large {
     background-color: $secondary;
+    border-color: $secondary;
     font-size: $sub-head;
     color: $textDark;
     text-align: left;
@@ -58,23 +57,20 @@
 
   &--inline {
     background-color: $primary;
+    border-color: $secondary;
     width: auto;
-    margin: 1em 0 20px 0;
-    padding: 0 10px;
+    margin: 1em 0;
+    padding: 0 20px;
     border: none;
   }
 }
 
 @media only screen and (max-width: 1024px) {
   .button {
-    min-width: 90%;
     height: 45px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .button {
-    min-width: 90%;
-    height: 45px;
+    
+    &--inline {
+      height: auto;
+    }
   }
 }


### PR DESCRIPTION
Add baseline border to avoid size changing when transitioning
Dry up code a bit

We won't be able to add the margin dynamically by calculating it with the current structure, so the easiest way to spread out buttons when there are several in the same container, that need to be in line, is to add (when needed)
```
& * {
... styles ...
}
```